### PR TITLE
Settings screen

### DIFF
--- a/Components/ConfirmDeleteAccount/ConfirmDeleteAccount.js
+++ b/Components/ConfirmDeleteAccount/ConfirmDeleteAccount.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet, Dimensions } from 'react-native';
+import * as Constants from '../../Constants/Constants';
+
+const ConfirmDeleteAccount = ({ handleDeleteAccount, cancelDelete }) => {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Delete Account</Text>
+      <Text style={styles.text}>Are you sure you want to delete your account?</Text>
+      <Text style={styles.text}>Your messages and account will be deleted permanently!</Text>
+      <TouchableOpacity style={styles.button} onPress={handleDeleteAccount}>
+        <Text style={styles.buttonText}>Yes</Text>
+      </TouchableOpacity>
+      <TouchableOpacity style={styles.button} onPress={cancelDelete}>
+        <Text style={styles.buttonText}>No</Text>
+      </TouchableOpacity>
+    </View>
+  )
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    backgroundColor: Constants.primaryBgColor,
+    paddingTop: 40,
+  },
+  header: {
+    color: 'white',
+    fontSize: 40,
+    marginVertical: Constants.baseMarginPadding,
+    fontFamily: 'exo-regular',
+  },
+  text: {
+    fontSize: 24,
+    textAlign: 'center',
+    marginVertical: 10,
+    color: 'white',
+    fontFamily: 'exo-regular',
+    width: Dimensions.get('window').width * .9,
+    marginVertical: 20,
+  },
+  button: {
+    width: Dimensions.get('window').width * .8,
+    backgroundColor: Constants.primaryHeaderColor, 
+    height: 50, 
+    display: 'flex', 
+    alignItems: 'center', 
+    justifyContent: 'center',
+    borderRadius: 4,
+    marginTop: Constants.baseMarginPadding,
+    borderColor: Constants.tertiaryBgColor,
+    borderWidth: 1,
+  },
+  buttonText: {
+    fontSize: 24,
+    color: Constants.tertiaryBgColor,
+    fontFamily: 'exo-regular',
+  }
+});
+
+
+export default ConfirmDeleteAccount

--- a/Components/Conversation/Conversation.js
+++ b/Components/Conversation/Conversation.js
@@ -8,7 +8,7 @@ import { getStatusBarHeight } from 'react-native-status-bar-height';
 
 export default class Conversation extends Component {
   renderMessages = () => {
-    const { messages } = this.props;
+    const { messages, deleteMessage } = this.props;
     return messages.map((message, i) => {
       return (
         <Message 
@@ -16,10 +16,17 @@ export default class Conversation extends Component {
           content={message.contents} 
           timestamp={message.timestamp}
           isSender={message.sender === true ? true: false}
+          deleteMessage={this.handleDeleteMessage}
         />
       );  
     });
   }
+
+  handleDeleteMessage = async (content, isSender) => {
+    const { deleteMessage, from } = this.props;
+    await deleteMessage(from, content, isSender);
+  }
+
   render() {
     const { from, messages, updateConversation, closeSelectedConversation } = this.props;
     const { email } = this.props.user;

--- a/Components/Message/Message.js
+++ b/Components/Message/Message.js
@@ -38,12 +38,20 @@ export default class Message extends Component {
     }
     return (
       <View style={isSender ? styles.senderContainer: styles.container}>
-        <TouchableOpacity onPress={() => deleteMessage(content, isSender ? true: false)}>
-          <Text>Delete</Text>
-        </TouchableOpacity>
-        <TouchableOpacity onPress={this.toggleShowDeleteMessage}>
-          <Text>Cancel</Text>
-        </TouchableOpacity>
+        <View style={styles.deleteContainer}>
+          <TouchableOpacity
+            onPress={() => deleteMessage(content, isSender ? true: false)}
+            style={styles.deleteBtn}
+          >
+            <Text style={isSender ? styles.senderContent: styles.content}>Delete</Text>
+          </TouchableOpacity>
+          <TouchableOpacity 
+            onPress={this.toggleShowDeleteMessage}
+            style={styles.deleteBtn}
+          >
+            <Text style={isSender ? styles.senderContent: styles.content}>Cancel</Text>
+          </TouchableOpacity>
+        </View>
       </View>  
     );
   }
@@ -54,9 +62,6 @@ export default class Message extends Component {
   }
 
   render() {
-    // const { content, timestamp, isSender, handleDeleteMessage } = this.props;
-    // const { showDeleteMessage } = this.state;
-    // const time = this.formatTimestamp(timestamp);
     return this.renderMessage();
   }
 }
@@ -74,11 +79,23 @@ const styles = StyleSheet.create({
     borderWidth: 1,
     marginLeft: 10,
   },
+  deleteContainer: {
+    width: '75%',
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    height: '100%',
+  },
+  deleteBtn: {
+    width: '50%',
+  },  
   content: {
     padding: 5,
     fontSize: 18,
     color: 'black',
     fontFamily: 'exo-regular',
+    textAlign: 'center',
   },
   timestamp: {
     alignSelf: 'flex-end',
@@ -105,6 +122,7 @@ const styles = StyleSheet.create({
     fontSize: 18,
     color: 'white',
     fontFamily: 'exo-regular',
+    textAlign: 'center',
   },
   senderTimestamp: {
     alignSelf: 'flex-end',

--- a/Components/Message/Message.js
+++ b/Components/Message/Message.js
@@ -3,6 +3,11 @@ import { Text, View, StyleSheet, Dimensions, TouchableOpacity } from 'react-nati
 import * as Constants from '../../Constants/Constants';
 
 export default class Message extends Component {
+
+  state = {
+    showDeleteMessage: false,
+  }
+
   formatTimestamp = (timestamp) => {
     const date = new Date(timestamp.seconds * 1000);
     let hours = Number(date.getHours());
@@ -18,15 +23,41 @@ export default class Message extends Component {
     }
     return `${hours}:${minutes} ${label}`;
   }
-  render() {
-    const { content, timestamp, isSender } = this.props;
+
+  renderMessage = () => {
+    const { content, timestamp, isSender, deleteMessage } = this.props;
+    const { showDeleteMessage } = this.state;
     const time = this.formatTimestamp(timestamp);
+    if(!showDeleteMessage) {
+      return (
+          <TouchableOpacity activeOpacity={0.75} style={isSender ? styles.senderContainer: styles.container} onLongPress={this.toggleShowDeleteMessage}>
+            <Text style={isSender ? styles.senderContent: styles.content}>{content}</Text>
+            <Text style={isSender ? styles.senderTimestamp: styles.timestamp}>{time}</Text>
+          </TouchableOpacity>
+      );
+    }
     return (
-      <TouchableOpacity activeOpacity={0.75} style={isSender ? styles.senderContainer: styles.container} onLongPress={() => alert('Want to delete this?')}>
-        <Text style={isSender ? styles.senderContent: styles.content}>{content}</Text>
-        <Text style={isSender ? styles.senderTimestamp: styles.timestamp}>{time}</Text>
-      </TouchableOpacity>
+      <View style={isSender ? styles.senderContainer: styles.container}>
+        <TouchableOpacity onPress={() => deleteMessage(content, isSender ? true: false)}>
+          <Text>Delete</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={this.toggleShowDeleteMessage}>
+          <Text>Cancel</Text>
+        </TouchableOpacity>
+      </View>  
     );
+  }
+    
+  toggleShowDeleteMessage = () => {
+    const { showDeleteMessage } = this.state;
+    this.setState({ showDeleteMessage: !showDeleteMessage });
+  }
+
+  render() {
+    // const { content, timestamp, isSender, handleDeleteMessage } = this.props;
+    // const { showDeleteMessage } = this.state;
+    // const time = this.formatTimestamp(timestamp);
+    return this.renderMessage();
   }
 }
 

--- a/Screens/Home/Home.js
+++ b/Screens/Home/Home.js
@@ -236,14 +236,15 @@ export default class Home extends Component {
       const { selectedConversation, user } = this.state;
       return (
         <Conversation
-        from={selectedConversation.from}
-        messages={selectedConversation.messages}
-        user={user}
-        updateConversation={this.updateConversation}
-        closeSelectedConversation={this.closeSelectedConversation}
-      />
-    );
-  }
+          from={selectedConversation.from}
+          messages={selectedConversation.messages}
+          user={user}
+          updateConversation={this.updateConversation}
+          closeSelectedConversation={this.closeSelectedConversation}
+          deleteMessage={this.deleteMessage}
+        />
+      );
+    } 
   
   toggleNewConversation = () => {
     this.setState({ showNewConversation: !this.state.showNewConversation });
@@ -308,6 +309,22 @@ export default class Home extends Component {
     storedMessages.sent = storedMessages.sent.filter((msg) => msg.to !== toDeleteFrom);
     await SecureStore.setItemAsync(user.email.replace('@', ''), JSON.stringify(storedMessages));
     this.setState({ conversations: updatedConversations, showDeleteConversationMenu: false, conversationToDelete: null });
+  }
+
+  deleteMessage = async (from, contents, isSender) => {
+    const { conversations, user } = this.state;
+    const conversation = conversations.find((convo) => convo.from === from);
+    const messageIndex = conversation.messages.findIndex((message) => message.contents === contents);
+    conversation.messages.splice(messageIndex, 1);
+    this.setState({ conversations });
+    let savedMessages = await SecureStore.getItemAsync(user.email.replace('@', ''));
+    savedMessages = JSON.parse(savedMessages);
+    if(isSender) {
+      savedMessages.sent = savedMessages.sent.filter((msg) => msg.contents !== contents);
+    } else {
+      savedMessages.inbox = savedMessages.inbox.filter((msg) => msg.contents !== contents);
+    }
+    await SecureStore.setItemAsync(user.email.replace('@', ''), JSON.stringify(savedMessages));
   }
 
   closeSelectedConversation = () => {

--- a/Screens/HomeNavigationContainer/HomeNavigationContainer.js
+++ b/Screens/HomeNavigationContainer/HomeNavigationContainer.js
@@ -45,8 +45,6 @@ export default createBottomTabNavigator(
         borderTopWidth: 1,
         height: Dimensions.get('window').height * .075,
       },
-      tabStyle: {
-      }
     }
   }
 );

--- a/Screens/Settings/Settings.js
+++ b/Screens/Settings/Settings.js
@@ -103,7 +103,7 @@ export default class Settings extends Component {
   }
 
   render() {
-    const { user, loadingFonts, showConfirmDeleteAccount } = this.state;
+    const { user, loadingFonts, showConfirmDeleteAccount, keysGenerated } = this.state;
     return (
       <View style={styles.container}>
         <View style={styles.profileContainer}>
@@ -116,7 +116,7 @@ export default class Settings extends Component {
           )}
         </View>
         {}
-        {this.state.keysGenerated && <Text>Successfully genereated new keys!</Text>}
+        { keysGenerated && <Text style={styles.successMsg}>Successfully generated new keys!</Text> }
         <TouchableOpacity 
           style={styles.button}
         >
@@ -163,6 +163,11 @@ const styles = StyleSheet.create({
     backgroundColor: Constants.primaryBgColor,
     paddingTop: 40,
   },
+  successMsg: {
+    color: Constants.tertiaryBgColor,
+    fontSize: 18,
+    marginVertical: 10,
+  },  
   profileContainer: {
     height: Dimensions.get('window').height * .2,
   },


### PR DESCRIPTION
#### What's this PR do?
Implement functionality for a basic settings screen. Allows the ability to regenerate keys, clear locally stored data, and delete the account. Also implements the ability to delete individual message from conversation screen. Displays message after successful key generation, and prompts user for confirmation to delete their account. Still needs some type of confirmation for clearing data.
#### Screenshots (if appropriate)
![settings](https://user-images.githubusercontent.com/25031031/77808317-74f30680-7050-11ea-8de7-df161b4f43ac.PNG)

