### PR TITLE
Add ability to detect if user is not found and msg cant be sent

### DIFF
--- a/Components/ComposeMessageForm/ComposeMessageForm.js
+++ b/Components/ComposeMessageForm/ComposeMessageForm.js
@@ -51,7 +51,7 @@ export default class ComposeMessageForm extends Component {
         return user.data().publicKey;
       }
       return false;
-    } catch(error) { console.error({ error })}
+    } catch(error) { return false }
   }
 
   sendMessage = async () => {
@@ -72,6 +72,11 @@ export default class ComposeMessageForm extends Component {
         sent: { seconds: sentSeconds },
       };
       const encryptedMessage = await this.encryptMessage(newMessage);
+      if(!encryptedMessage) {
+        alert('Could not send message, user not found!');
+        this.setState({ message: '' });
+        return;
+      }
       await firebase.firestore().collection('users').doc(to).collection('inbox').add(encryptedMessage);
       Keyboard.dismiss();
       this.setState({message: '', focused: false });


### PR DESCRIPTION
#### What's this PR do?
Implement functionality to detect when a message can't be sent because the recipient has deleted their account. Will need to add additional functionality to handle the event of a conversation recipient being deleted(Disable send msg button, prompt user to keep/delete convo)
#### Where should the reviewer start?
Create two accounts, send a message from one account to the other. Delete one of the accounts and attempt to send a message to the deleted account. A console message should be displayed indicating the user has been deleted.
#### Any background context you want to provide?
Will need to build on functionality implemented in this PR.
#### Relevant Tickets
#84 
