### PR TITLE
Add functionality to periodically check for and retrieve new messages

### DIFF
--- a/Screens/Home/Home.js
+++ b/Screens/Home/Home.js
@@ -36,6 +36,7 @@ export default class Home extends Component {
     showDeleteConversationMenu: false,
     refreshing: false,
     loadingFonts: true,
+    updating: false,
   };
 
 
@@ -58,6 +59,7 @@ export default class Home extends Component {
 
   getMessages = async (user) => {  
     try{
+      this.setState({ updating: true });
       const inboxSnap = await firebase.firestore().collection('users').doc(user.email).collection('inbox').get();
       const inbox = await inboxSnap.docs.map((doc) => doc.data());
       if(inbox.length > 0) {
@@ -70,14 +72,10 @@ export default class Home extends Component {
         const conversations = await this.buildConversations(builtMessages);
         this.setState({ conversations });
       }
-      if(this.state.refreshing) {
-        this.setState({ refreshing: false });
-      }
+      this.setState({ updating: false });
     } catch(error) {
-      if(this.state.refreshing) {
-        this.setState({ refreshing: false });
-      }
-      console.log({error});
+        this.setState({ updating: false });
+        console.log({error});
     }
   };
 
@@ -332,11 +330,13 @@ export default class Home extends Component {
   }
 
   render() {
-    const { refreshing, user, showDeleteConversationMenu } = this.state;
-    // setTimeout(() => {
-    //   this.getMessages(user);
-    // }, 5000);
+    const { refreshing, updating, user, showDeleteConversationMenu, selectedConversation } = this.state;
     const { navigate } = this.props.navigation;
+    if(!selectedConversation && !refreshing && !updating ) {
+      setTimeout(async () => {
+        await this.getMessages(user);
+      }, 15000);
+    }
     return (
       <View style={styles.container}>
         <StatusBar barStyle="light-content" />


### PR DESCRIPTION
#### What's this PR do?
Fixes auto fetching of new messages by restructuring getMessages and the setTimout method used to continuously trigger the method. The application now brings in new messages automatically when they do not have a conversation open. Will add a method to the conversation screen to look for new messages from that user periodically. Messages are currently synced every 15 seconds.
#### How should this be manually tested?
Send a message from one account to another with the recipient's account signed in and open. You should no longer need to manually pull-to-refresh or reload the app to see new messages.
#### What are the relevant tickets?
#64 
